### PR TITLE
changing z-index so 'address' appears below 'London 2016' on mobile

### DIFF
--- a/style/mixins/hex-badge.styl
+++ b/style/mixins/hex-badge.styl
@@ -5,7 +5,7 @@ hexa-badge(dir = 'top', badge-height = 22px, bg-color = darken(color-blue, 10))
     margin (badge-height / -2) 0
     left 50%
     transform translateX(-50%)
-    z-index 9
+    z-index 8
 
     if dir == 'top'
         top 0


### PR DESCRIPTION
Having the 2 "hexa-badges" with the same `z-index` causes issues on mobile devices, with the 'Address' one appearing above the 'London 2016' one (see screenshot)
<img width="400" alt="before" src="https://cloud.githubusercontent.com/assets/1452247/14000092/72d1beec-f137-11e5-9702-678160aa2b34.png">

Changing `z-index` on `.hexa-badge` (which on;y affects the 'Address' one) to 8 fixes this issue (see second screenshot below)
<img width="399" alt="after" src="https://cloud.githubusercontent.com/assets/1452247/14000091/72b41dd8-f137-11e5-9fc4-23c3546b5f3e.png">
